### PR TITLE
Add a `renderer` kwarg to FileBrowseWidget.render

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -12,6 +12,7 @@ from django.db.models.fields.files import FileDescriptor
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from filebrowser_safe.settings import *
@@ -34,7 +35,7 @@ class FileBrowseWidget(Input):
         else:
             self.attrs = {}
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ""
         directory = self.directory
@@ -51,7 +52,10 @@ class FileBrowseWidget(Input):
         final_attrs['extensions'] = self.extensions
         final_attrs['format'] = self.format
         final_attrs['DEBUG'] = DEBUG
-        return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
+        if renderer is not None:
+            return mark_safe(renderer.render("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL)))
+        else:
+            return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
 
 
 class FileBrowseFormField(forms.CharField):


### PR DESCRIPTION
@petedermott Here is the change to address the "TypeError at /admin/galleries/gallery/8/change/ render() got an unexpected keyword argument 'renderer'" I was experiencing when running a test site instance on Django 2.2 with the included example site contents.

The cause of the problem is that in Django 1.11, the call sign for `Widget.render` in `django/forms/widgets` changed to include a `renderer` argument.  In that same release, the `BoundField.as_widget` method in `django/forms/boundfield` also changed to include a warning that the `renderer` argument would be mandatory in Django 2.1.  However, for some reason, it looks like that warning never got printed when one attempted to edit the "Gallery" page under Django 1.11.  (I created a test install on my machine today using Django 1.11 and the master branches of the official Mezzanine, grappelli-safe, and filebrowser-safe repos, and did not find the warning listed anywhere in the output of `runserver`.)  My guess is that, understandably, the lack of this visual warning prevented this change from being noticed until now.

I have changed the `FileBrowseWidget.render` method so that it can now accept and use the `renderer` argument.  As of Django 1.11, the base `Widget` class now has working code in its `render` method, so I referenced the code invoked through that method to determine the correct logic for the `FileBrowseWidget` changes.

The `renderer` that gets passed to the `FileBrowseWidget.render` method will be a `django.forms.renderers.DjangoTemplates` object, assuming that the user hasn't specified a different template engine in their settings file.  I have compared the output of the new renderer code against that of the old `render_to_string` call and have found that the only difference is cosmetic: the old code added a newline to the beginning of the HTML snippet and four newlines at the end; the new renderer strips these out due to a call to `strip` contained in the `BaseRenderer` class.

I agonized quite a bit over whether or not it was safe to use `mark_safe` on the output from the renderer.  However, the Django docs state that the included renderers produce escaped output unless explicitly turned off by the user, and gives warnings for users not to do this.  I used PDB to inspect the output of the new DjangoTemplates engine and it is actually marked as a SafeText object up until the final step where the strip call inherited from the `BaseRender` class gets triggered.  This, combined with the fact that the base `Widget` class' `render` method also uses `mark_safe` on the returned code, has lead me to believe that it is safe.

I have tested the patch on both a Django 2.2 instance running your other forked branches, and a Django 1.11 instance running the official Mezzanine and grappelli-safe master branches, and have found no problems with the changes on either instance.  In fact, the Django 1.11 instance also takes the new code path, so there is a very high chance that the old `render_to_string` call is now a dead code path.  However, I thought it might be prudent to leave it in for a release or two, since there may be possible issues that I am not seeing or others may have custom code that relies on this functionality.

Hopefully this patch is of use.  If I have missed anything, please just let me know.  I would be especially grateful if someone could check that my understanding of `mark_safe` in this context is correct, since I would hate to accidentally introduce a security risk to Mezzanine.  Thank you, and I apologize that this didn't end up succinct at all.
